### PR TITLE
Fixed waffle setup instructions

### DIFF
--- a/build/development-guide/smart-contracts/get-started-evm/use-waffle.md
+++ b/build/development-guide/smart-contracts/get-started-evm/use-waffle.md
@@ -2,10 +2,10 @@
 
 There are multiple tools you can use to develop and compile Solidity contracts, we'd present two here as options
 
-* online web app Remix 
-* Solidity development and testing framework Waffle
+- online web app Remix
+- Solidity development and testing framework Waffle
 
-### Compile Solidity Contract using Waffle Comment
+## Compile Solidity Contract using Waffle
 
 **Note:** you can skip this section if you compiled the smart contract with Remix.
 
@@ -13,7 +13,7 @@ This guide walks through the process of deploying a Solidity-based smart contrac
 
 ### **1. Check Prerequisites**
 
-First, we need to install Node.js \(we use v15.x in this example\) and the npm package manager. You can do this by running in your terminal:
+First, we need to install Node.js \(we use v15.x in this example\) and the yarn package manager. You can do this by running in your terminal:
 
 ```text
 curl -sL https://deb.nodesource.com/setup_15.x | sudo -E bash -
@@ -21,6 +21,8 @@ curl -sL https://deb.nodesource.com/setup_15.x | sudo -E bash -
 
 ```text
 sudo apt install -y nodejs
+
+npm install --global yarn
 ```
 
 We can verify that everything installed correctly by querying the version for each package:
@@ -30,10 +32,10 @@ node -v
 ```
 
 ```text
-npm -v
+yarn -v
 ```
 
-### **2. Install Waffle**
+### **2. Using Waffle With Our Examples**
 
 We've made it easy by collecting all required dependencies in the [AcalaNetwork/evm-examples](https://github.com/AcalaNetwork/evm-examples) repo.
 
@@ -41,32 +43,40 @@ Simply clone the repository and install the dependencies.
 
 ```text
 git clone https://github.com/AcalaNetwork/evm-examples
-cd evm-examples
 
-npm install 
-# or
+cd evm-examples/erc20
+
 yarn install
 ```
 
-Alternatively, you can install each library separately as the following: 
+After you've installed the dependencies, you can compile the Solidity smart contract in the `contracts` folder by running the following command:
+
+```text
+yarn waffle
+```
+
+### **3. Using Waffle from Scratch**
+
+Alternatively, you can setup waffle from scratch by doing the following:
 
 Create a folder
 
 ```text
 mkdir smart-contract-waffle
+
 cd smart-contract-waffle
 ```
 
 Init npm dependencies
 
 ```text
-npm init -y
+yarn init -y
 ```
 
 Install all required dependencies
 
 ```text
-npm i -D @openzeppelin/contracts@3.3.0 ethereum-waffle@3.2.1 
+yarn add --dev @openzeppelin/contracts@3.3.0 ethereum-waffle@3.2.1
 ```
 
 Note: it's recommended to install dependencies with exact versions as specified to avoid breaking changes.
@@ -90,12 +100,9 @@ Paste the following in the `waffle.json` file
 
 This sets up the solidity compiler with version `0.6.2`, compiles contracts from the `./contracts` folder, and saves the bytecode output and ABI files to `./build` folder.
 
-### **3. Compile the Solidity Con**t**ract**
-
 Now create the `./contracts` folder, and add the `BasicToken.sol` contract.
 
 ```text
-
 mkdir contracts
 touch contracts/BasicToken.sol
 ```
@@ -113,20 +120,18 @@ contract BasicToken is ERC20 {
         _mint(msg.sender, initialBalance);
     }
 }
-
 ```
 
-Now compile the contract into ABI and bytecode. Run the following in the terminal
+Now compile the contract into ABI and bytecode. Within the folder containing `waffle.json` run the following in the terminal:
 
 ```text
-npx waffle
+yarn waffle
 ```
 
-### **4. Get the ABI file**
+### **3. Get the ABI file**
 
-Waffle will then generate the output file `./build/BasicToken.json` into the `./build` folder. 
+Waffle will then generate the output file `./build/BasicToken.json` into the `./build` folder.
 
 Note: this file should be the same as the one created with Remix.
 
 Waffle also provides a full suite of testing utilities, check out their documentation and code samples [here](https://github.com/EthWorks/Waffle).
-


### PR DESCRIPTION
I changed the flow of the page to be a bit more coherent depending on whether the reader chose to use our examples or set up waffle from scratch. I also changed the article to use yarn instead of npm as I was not able to get the `evm-example` contracts to work using npm on the two machines I tried it on.