### PR TITLE
Reworked deploy contract pages

### DIFF
--- a/build/development-guide/deploy-smart-contracts/get-started/deploy-contracts.md
+++ b/build/development-guide/deploy-smart-contracts/get-started/deploy-contracts.md
@@ -2,7 +2,35 @@
 
 The `Acala EVM Playground` is useful to test various functionalities of Acala EVM. The source code is [here](https://github.com/AcalaNetwork/evm-playground) and it’s a fork from parity `canvas-ui`.
 
-### **1. Upload Contract ABI**
+### **1. Setup**
+
+To deploy your contract on a node you have two options:
+
+**Deploy to a local dev node**
+
+To deploy to a local dev node you first need to follow the `Building` instructions here [https://github.com/AcalaNetwork/Acala#3-building](https://github.com/AcalaNetwork/Acala#3-building).
+
+Once you have built Acala you can start an evm ready local dev node by running the following command:
+
+```text
+make run-eth
+```
+
+After your dev node is up and running you can set the Acala evm playground to point to your node by clicking dropdown in the bottom left corner and selecting `Local Node`.
+
+![](https://i.imgur.com/4hndMwf.jpg)
+
+Running the local dev node will preopulate the `Accounts` dropdowns with pre-funded developer accounts.
+
+**Deploy to our test network**
+
+To deploy to our test network you need have the [polkadot{.js}](https://polkadot.js.org/extension/) wallet extension installed in your browser.
+
+Once you have the extension installed, you can bind your accounts with an evm address and get test network funds on the `Setup EVM Account` page on the Acala evm playground. For more in depth instructions, read the documentation [here](https://wiki.acala.network/build/development-guide/smart-contracts/get-started-evm/evm-account).
+
+**Note:** For the remainder of this page we will assume you are using a local dev node. If you are deploying to the test network using the `polkadot{.js}` extension simply replace the accounts `Alice`, and `Bob` with the accounts you have set up in your extension.
+
+### **2. Upload Contract ABI**
 
 Deploy the `BasicToken` ABI file by navigating to [https://evm.acala.network/](https://evm.acala.network/).
 
@@ -10,19 +38,17 @@ Go to the `Upload` tab.
 
 ![](https://i.imgur.com/WEqKIwg.png)
 
-Fill in the contract name, then upload the contract ABI`BasicToken.json`.
+Fill in the contract name, then upload the contract ABI `BasicToken.json`.
 
 ![](https://i.imgur.com/35cPG16.png)
 
-Then it would display a list of available methods in the contract. Then click `Upload`.
+It will then display a list of available methods in the contract. Then click `Upload`.
 
-### **2. Deploy the Contract**
+### **3. Deploy the Contract**
 
-After uploading the ABI, the Playground would automatically navigate to the `Upload` step. If not, just select `Deploy` in the left sidebar. `BasicToken` shall appear in the `ABI bundles`.
+After uploading the ABI, the Playground will automatically navigate to the `Upload` step. If not, just select `Deploy` in the left sidebar. `BasicToken` shall appear in the `ABI bundles`.
 
-Click the `Deploy` button, and choose `Alice` as the `deployment account`.
-
-Note: the test network has been pre-loaded with a few developer accounts, and Alice is one of the pre-funded accounts.
+Click the `Deploy` button, and choose `Alice` (or your account if using the browser extension) as the `deployment account`.
 
 ![](https://i.imgur.com/49maXFG.png)
 
@@ -34,7 +60,7 @@ The deployed `BasicToken` contract should appear in the execute section.
 
 ![](https://i.imgur.com/BMp4SR3.png)
 
-### **3. Interact with the Contract**
+### **4. Interact with the Contract**
 
 Navigate to the `Execute` tab. Find the deployed `BasicToken` contract.
 
@@ -42,40 +68,40 @@ Click the `Execute` button.
 
 ![](https://i.imgur.com/eOnKfQi.png)
 
-### **4. Query Balances**
+### **5. Query Balances**
 
-Pick `balanceOf` from the `Message to Send` dropdown.
+To perform a query on an account's balance, do the following steps:
 
-Select `Alice` from the `Call from Account` dropdown. This is the account used to send the transaction.
+1. Select `Alice` from the `Call from Account` dropdown. This is the account used to send the transaction.
 
-Find Alice’s EVM Address under `Call from Account` , copy and paste it in the `account: address` argument box.
+2. Pick `balanceOf` from the `Message to Send` dropdown.
+
+3. Find Alice’s EVM Address under `Call from Account` , copy and paste it in the `account: address` argument box.
 
 ![](https://i.imgur.com/ups2Ur6.png)
-
-Press `Call` and check out the returned results below.
 
 **Note:** Solidity contracts have two types of methods: `views` and `executable` methods.
 
 - `Views` are used to query information from the blockchain without writing data to it. `Views` transactions are free. The Playground uses the `Call` button to indicate this.
 - `Executable` methods can write data onto the blockchain, and these transactions aren’t free. Click the `Execute` button to execute it.
 
+Finally, click the `Call` button and `Call results` should show the BasicToken balance of Alice.
+
 ![](https://i.imgur.com/URot8MK.png)
 
-`Call results` should show the BasicToken balance of Alice.
+### **6. Transfer**
 
-### **5. Transfer**
+Now lets try transfering BasicTokens to Bob’s Account.
 
-Now try transfer BasicTokens to Bob’s Account.
+1. Select `Alice` from the account dropdown.
 
-Select Bob’s account from the `Call from Account` dropdown, then copy its `EVM address`.
+2. Select `transfer` from the `Message to Send` dropdown.
 
-Switch account back to Alice, select `transfer` from the `Message to Send` dropdown.
+3. Select Bob’s account from the `Call from Account` dropdown, then copy its `EVM address` and paste it in the `recipient address` input box. (Remember to switch `Call from Account` back to `Alice`)
 
-Paste Bob’s EVM address in the `recipient address` input box.
+4. Enter transfer amount in the `amount: unit256` argument box, note the token has a standard 18 decimals.
 
-Then enter transfer amount in the `amount: unit256` argument box, note the token has a standard 18 decimals.
-
-Click `Execute`.
+5. Click `Execute`.
 
 ![](https://i.imgur.com/hPAGjsT.png)
 

--- a/build/development-guide/smart-contracts/get-started-evm/deploy-contracts.md
+++ b/build/development-guide/smart-contracts/get-started-evm/deploy-contracts.md
@@ -2,7 +2,35 @@
 
 The `Acala EVM Playground` is useful to test various functionalities of Acala EVM. The source code is [here](https://github.com/AcalaNetwork/evm-playground) and it’s a fork from parity `canvas-ui`.
 
-## **1. Upload Contract ABI**
+### **1. Setup**
+
+To deploy your contract on a node you have two options:
+
+**Deploy to a local dev node**
+
+To deploy to a local dev node you first need to follow the `Building` instructions here [https://github.com/AcalaNetwork/Acala#3-building](https://github.com/AcalaNetwork/Acala#3-building).
+
+Once you have built Acala you can start an evm ready local dev node by running the following command:
+
+```text
+make run-eth
+```
+
+After your dev node is up and running you can set the Acala evm playground to point to your node by clicking dropdown in the bottom left corner and selecting `Local Node`.
+
+![](https://i.imgur.com/4hndMwf.jpg)
+
+Running the local dev node will preopulate the `Accounts` dropdowns with pre-funded developer accounts.
+
+**Deploy to our test network**
+
+To deploy to our test network you need have the [polkadot{.js}](https://polkadot.js.org/extension/) wallet extension installed in your browser.
+
+Once you have the extension installed, you can bind your accounts with an evm address and get test network funds on the `Setup EVM Account` page on the Acala evm playground. For more in depth instructions, read the documentation [here](https://wiki.acala.network/build/development-guide/smart-contracts/get-started-evm/evm-account).
+
+**Note:** For the remainder of this page we will assume you are using a local dev node. If you are deploying to the test network using the `polkadot{.js}` extension simply replace the accounts `Alice`, and `Bob` with the accounts you have set up in your extension.
+
+### **2. Upload Contract ABI**
 
 Deploy the `BasicToken` ABI file by navigating to [https://evm.acala.network/](https://evm.acala.network/).
 
@@ -14,15 +42,13 @@ Fill in the contract name, then upload the contract ABI `BasicToken.json`.
 
 ![](https://i.imgur.com/35cPG16.png)
 
-Then it would display a list of available methods in the contract. Then click `Upload`.
+It will then display a list of available methods in the contract. Then click `Upload`.
 
-## **2. Deploy the Contract**
+### **3. Deploy the Contract**
 
-After uploading the ABI, the Playground would automatically navigate to the `Upload` step. If not, just select `Deploy` in the left sidebar. `BasicToken` shall appear in the `ABI bundles`.
+After uploading the ABI, the Playground will automatically navigate to the `Upload` step. If not, just select `Deploy` in the left sidebar. `BasicToken` shall appear in the `ABI bundles`.
 
-Click the `Deploy` button, and choose `Alice` as the `deployment account`.
-
-Note: the test network has been pre-loaded with a few developer accounts, and Alice is one of the pre-funded accounts.
+Click the `Deploy` button, and choose `Alice` (or your account if using the browser extension) as the `deployment account`.
 
 ![](https://i.imgur.com/49maXFG.png)
 
@@ -34,7 +60,7 @@ The deployed `BasicToken` contract should appear in the execute section.
 
 ![](https://i.imgur.com/BMp4SR3.png)
 
-## **3. Interact with the Contract**
+### **4. Interact with the Contract**
 
 Navigate to the `Execute` tab. Find the deployed `BasicToken` contract.
 
@@ -42,40 +68,40 @@ Click the `Execute` button.
 
 ![](https://i.imgur.com/eOnKfQi.png)
 
-## **4. Query Balances**
+### **5. Query Balances**
 
-Pick `balanceOf` from the `Message to Send` dropdown.
+To perform a query on an account's balance, do the following steps:
 
-Select `Alice` from the `Call from Account` dropdown. This is the account used to send the transaction.
+1. Select `Alice` from the `Call from Account` dropdown. This is the account used to send the transaction.
 
-Find Alice’s EVM Address under `Call from Account` , copy and paste it in the `account: address` argument box.
+2. Pick `balanceOf` from the `Message to Send` dropdown.
+
+3. Find Alice’s EVM Address under `Call from Account` , copy and paste it in the `account: address` argument box.
 
 ![](https://i.imgur.com/ups2Ur6.png)
 
-Press `Call` and check out the returned results below.
-
 **Note:** Solidity contracts have two types of methods: `views` and `executable` methods.
 
-* `Views` are used to query information from the blockchain without writing data to it. `Views` transactions are free. The Playground uses the `Call` button to indicate this.
-* `Executable` methods can write data onto the blockchain, and these transactions aren’t free. Click the `Execute` button to execute it.
+- `Views` are used to query information from the blockchain without writing data to it. `Views` transactions are free. The Playground uses the `Call` button to indicate this.
+- `Executable` methods can write data onto the blockchain, and these transactions aren’t free. Click the `Execute` button to execute it.
+
+Finally, click the `Call` button and `Call results` should show the BasicToken balance of Alice.
 
 ![](https://i.imgur.com/URot8MK.png)
 
-`Call results` should show the BasicToken balance of Alice.
+### **6. Transfer**
 
-## **5. Transfer**
+Now lets try transfering BasicTokens to Bob’s Account.
 
-Now try transfer BasicTokens to Bob’s Account.
+1. Select `Alice` from the account dropdown.
 
-Select Bob’s account from the `Call from Account` dropdown, then copy its `EVM address`.
+2. Select `transfer` from the `Message to Send` dropdown.
 
-Switch account back to Alice, select `transfer` from the `Message to Send` dropdown.
+3. Select Bob’s account from the `Call from Account` dropdown, then copy its `EVM address` and paste it in the `recipient address` input box. (Remember to switch `Call from Account` back to `Alice`)
 
-Paste Bob’s EVM address in the `recipient address` input box.
+4. Enter transfer amount in the `amount: unit256` argument box, note the token has a standard 18 decimals.
 
-Then enter transfer amount in the `amount: unit256` argument box, note the token has a standard 18 decimals.
-
-Click `Execute`.
+5. Click `Execute`.
 
 ![](https://i.imgur.com/hPAGjsT.png)
 
@@ -88,4 +114,3 @@ Now check the balances of Alice and Bob, how have they changed?
 ![](https://i.imgur.com/mTLZGYU.png)
 
 ![](https://i.imgur.com/tTSS4gs.png)
-


### PR DESCRIPTION
Reformatted the instructions to follow the numbers labeled in the pictures and added information on using a local dev node vs. using the test net.