### PR TITLE
Fixed a typo in the name of the docker image

### DIFF
--- a/build/development-guide/deploy-smart-contracts/get-started/connect-to-a-node.md
+++ b/build/development-guide/deploy-smart-contracts/get-started/connect-to-a-node.md
@@ -18,8 +18,8 @@ docker version
 If you receive the version number, you can start your local Acala node with the command below:
 
 ```text
-docker pull acala/aca-node:latest
-docker run -it -p 9944:9944 -p 9933:9933 acala/aca-node:latest --dev --ws-external --rpc-external --rpc-cors=all
+docker pull acala/acala-node:latest
+docker run -it -p 9944:9944 -p 9933:9933 acala/acala-node:latest --dev --ws-external --rpc-external --rpc-cors=all
 ```
 
 The output of your node should look like this:

--- a/build/development-guide/smart-contracts/get-started-evm/connect-to-a-node.md
+++ b/build/development-guide/smart-contracts/get-started-evm/connect-to-a-node.md
@@ -22,8 +22,8 @@ docker version
 If you receive the version number, you can start your local Acala node with the command below:
 
 ```bash
-docker pull acala/aca-node:latest
-docker run -it -p 9944:9944 -p 9933:9933 acala/aca-node:latest --dev --ws-external --rpc-external --rpc-cors=all
+docker pull acala/acala-node:latest
+docker run -it -p 9944:9944 -p 9933:9933 acala/acala-node:latest --dev --ws-external --rpc-external --rpc-cors=all
 ```
 
 The output of your node should look like this:

--- a/maintain/network-maintainers/node-management.md
+++ b/maintain/network-maintainers/node-management.md
@@ -116,7 +116,7 @@ docker run -p 9944:9944 acala/acala-node:latest --name "calling_home_from_a_dock
 **Using Docker**
 
 ```text
-docker run -d --restart=always -p 30333:30333 -p 9933:9933 -p 9944:9944 -v /root/aca-node:/acala/data acala/acala-node:latest --chain karura --collator
+docker run -d --restart=always -p 30333:30333 -p 9933:9933 -p 9944:9944 -v /root/acala-node:/acala/data acala/acala-node:latest --chain karura --collator
 ```
 
 #### For Acala \(Coming Soon\)
@@ -124,7 +124,7 @@ docker run -d --restart=always -p 30333:30333 -p 9933:9933 -p 9944:9944 -v /root
 **Using Docker**
 
 ```text
-docker run -d --restart=always -p 30333:30333 -p 9933:9933 -p 9944:9944 -v /root/aca-node:/acala/data acala/acala-node:latest --chain acala --collator
+docker run -d --restart=always -p 30333:30333 -p 9933:9933 -p 9944:9944 -v /root/acala-node:/acala/data acala/acala-node:latest --chain acala --collator
 ```
 
 ### Run as full node
@@ -134,7 +134,7 @@ docker run -d --restart=always -p 30333:30333 -p 9933:9933 -p 9944:9944 -v /root
 **Using Docker**
 
 ```text
-docker run -d --restart=always -p 30333:30333 -p 9933:9933 -p 9944:9944 -v /root/aca-node:/acala/data acala/acala-node:latest --chain karura
+docker run -d --restart=always -p 30333:30333 -p 9933:9933 -p 9944:9944 -v /root/acala-node:/acala/data acala/acala-node:latest --chain karura
 ```
 
 #### For Acala \(Coming Soon\)
@@ -142,7 +142,7 @@ docker run -d --restart=always -p 30333:30333 -p 9933:9933 -p 9944:9944 -v /root
 **Using Docker**
 
 ```text
-docker run -d --restart=always -p 30333:30333 -p 9933:9933 -p 9944:9944 -v /root/aca-node:/acala/data acala/acala-node:latest --chain acala
+docker run -d --restart=always -p 30333:30333 -p 9933:9933 -p 9944:9944 -v /root/acala-node:/acala/data acala/acala-node:latest --chain acala
 ```
 
 ## TestNet
@@ -152,7 +152,7 @@ docker run -d --restart=always -p 30333:30333 -p 9933:9933 -p 9944:9944 -v /root
 #### **Using Docker**
 
 ```text
-docker run -d --restart=always -p 30333:30333 -p 9933:9933 -p 9944:9944 -v /root/aca-node:/acala/data acala/acala-node:latest --chain mandala
+docker run -d --restart=always -p 30333:30333 -p 9933:9933 -p 9944:9944 -v /root/acala-node:/acala/data acala/acala-node:latest --chain mandala
 ```
 
 ### Run as local testnet


### PR DESCRIPTION
Updated the docker image name so the commands in the tutorial pages can be copy-pasted and run as is.