### PR TITLE
Fix the link to Scheduler source code in Use On-chain Scheduler chapter

### DIFF
--- a/build/development-guide/smart-contracts/advanced/use-on-chain-scheduler/README.md
+++ b/build/development-guide/smart-contracts/advanced/use-on-chain-scheduler/README.md
@@ -2,7 +2,7 @@
 
 You can use the on-chain scheduler contract to schedule a recurring call to execute a given smart contract. Read more on use cases for the on-chain auto-scheduler [here](https://wiki.acala.network/learn/basics/acala-evm/acala-evm-composable-defi-stack/on-chain-scheduler).
 
-Contract source code [here](https://wiki.acala.network/learn/basics/acala-evm/acala-evm-composable-defi-stack/on-chain-scheduler).
+Contract source code [here](https://github.com/AcalaNetwork/predeploy-contracts/blob/master/contracts/schedule/Schedule.sol).
 
 Note: the `min_delay` is minimum number of blocks after current blocks before the scheduled call will be called. i.e. Pass 0 means it will be scheduled to be called on next block. Calling `scheduleCall` with `min_delay = 5` on block 10 will scheduled the call on block `10 + 1 + 5 = 16`. If the block are full or there are too many other scheduled tasks, the scheduled call could be deferred to later blocks until there is enough remaining spaces in the block.
 


### PR DESCRIPTION
The link that was supposed to link to the Scheduler source code, led to the On-chain Scheduler chapter. I replaced it with the link to the Scheduler source code on master branch.